### PR TITLE
[#120368533] Add set_mtu job

### DIFF
--- a/jobs/set_mtu/spec
+++ b/jobs/set_mtu/spec
@@ -1,0 +1,14 @@
+---
+name: set_mtu
+
+templates:
+  pre-start.sh.erb: bin/pre-start
+
+properties:
+  set_mtu.interface:
+    description: Network interface name.
+    default: eth0
+
+  set_mtu.mtu:
+    description: MTU (Maximum Transmission Unit) value in bytes
+    default: 1500

--- a/jobs/set_mtu/templates/pre-start.sh.erb
+++ b/jobs/set_mtu/templates/pre-start.sh.erb
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+INTERFACE=<%= p('set_mtu.interface') %>
+MTU=<%= p('set_mtu.mtu') %>
+
+DHCP_HOOK=/etc/dhcp/dhclient-exit-hooks.d/set_mtu
+
+# Override MTU setting when DHCP lease is renewed
+cat <<EOF > ${DHCP_HOOK}
+#!/bin/sh
+ifconfig ${INTERFACE} mtu ${MTU}
+EOF
+chmod +x ${DHCP_HOOK}
+
+# Enable new MTU setting now
+${DHCP_HOOK}

--- a/manifests/set_mtu.yaml
+++ b/manifests/set_mtu.yaml
@@ -1,0 +1,13 @@
+releases:
+- name: os-conf
+  version: <RELEASE VERSION>
+
+addons:
+- name: os-configuration
+  jobs:
+  - name: set_mtu
+    release: os-conf
+  properties:
+    set_mtu:
+      interface: eth0
+      mtu: 1500


### PR DESCRIPTION
# What

Story: [Reduce MTU of VMs to 1500](https://www.pivotaltracker.com/story/show/120368533)

We have discovered an MTU related problem with AWS's nat-gateway service which is causing us all sorts of problems at the moment, including:
- 'Error tailing logs: Unexpected EOF'. Seems to be that doppler cannot properly validate the auth token with the  UAA (presumably because it's using the UAA endpoint URL and that's being routed out via the aws-nat-gateway)
- 'Stats unavailable: Stats server temporarily unavailable.' Seems to be a problem with tps-listener failing to connect to the doppler endpoint

The MTU is different for different machine sizes on AWS, but a lot of the larger ones (which we're using) now default to using Jumbo frames, with MTU 9001. AWS doesn't give us enough control over the dhcp-option-sets to set the MTU for ourselves.

The problem doesn't happen if you spin up your own nat-masquerading linux box. AWS has confirmed they see the problem when we sent them some code to try out MTU sizes from 1513 to 517 bytes. They say the've worked out a fix and will deploy it by 30th June

The bosh-agent seems to overwrite the dhclient.conf when it starts up. But we can use a bosh addon to write a DHCP hook to set the MTU whenever the lease is renewed.
# How to review

Review with MTU PR on paas-cf
# Note

Once this is merged, update MTU on paas-cf to point to merge commit id
# Who can review

Anyone but @jimconner or me
