### PR TITLE
[#131975557] Add a job that cleans up metron_agent's redirection

### DIFF
--- a/jobs/cleanup_syslog_forwarding/monit
+++ b/jobs/cleanup_syslog_forwarding/monit
@@ -1,0 +1,7 @@
+check process cleanup_syslog_forwarding
+  with pidfile /var/vcap/sys/run/cleanup_syslog_forwarding/pid
+  start program "/var/vcap/jobs/cleanup_syslog_forwarding/bin/cleanup_syslog_forwarding_ctl start"
+  stop program "/var/vcap/jobs/cleanup_syslog_forwarding/bin/cleanup_syslog_forwarding_ctl stop"
+  <% if !p('cleanup_syslog_forwarding.depends_on').empty? %>
+  depends on <%= p('cleanup_syslog_forwarding.depends_on').join(', ') %>
+  <% end %>

--- a/jobs/cleanup_syslog_forwarding/spec
+++ b/jobs/cleanup_syslog_forwarding/spec
@@ -1,0 +1,13 @@
+---
+name: cleanup_syslog_forwarding
+
+templates:
+  cleanup_syslog_forwarding_ctl.erb: bin/cleanup_syslog_forwarding_ctl
+
+properties:
+  syslog_daemon_config.enable:
+    description: "Enable or disable rsyslog configuration for forwarding syslog messages into metron"
+    default: true
+  cleanup_syslog_forwarding.depends_on:
+    description: "Run our monit service after these other monit services"
+    default: []

--- a/jobs/cleanup_syslog_forwarding/templates/cleanup_syslog_forwarding_ctl.erb
+++ b/jobs/cleanup_syslog_forwarding/templates/cleanup_syslog_forwarding_ctl.erb
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+RUN_DIR=/var/vcap/sys/run/cleanup_syslog_forwarding
+PIDFILE="${RUN_DIR}/pid"
+
+case $1 in
+
+  start)
+    mkdir -p $RUN_DIR
+    chown -R vcap:vcap $RUN_DIR
+
+    # Record a pidfile so monit thinks we are running as a service
+    echo 1 > "${PIDFILE}"
+
+<% if !p('syslog_daemon_config.enable') %>
+    # Cleanup metron_agent's rsyslog config, if present
+    CONFIG_FILE="/etc/rsyslog.d/00-syslog_forwarder.conf"
+    if [ -f "${CONFIG_FILE}" ]; then
+        rm -f "${CONFIG_FILE}"
+        /usr/sbin/service rsyslog restart
+    fi
+<% end %>
+
+    ;;
+
+  stop)
+    rm -f "${PIDFILE}"
+
+    ;;
+
+  *)
+    echo "Usage: $0 {start,stop}"
+
+    ;;
+esac


### PR DESCRIPTION
[#131975557](https://www.pivotaltracker.com/n/projects/1275640/stories/131975557) Alternate solution to configure syslog forwarding without metron agent
# What

metron_agent will configure rsyslogd to forward logs via relp when `syslog_daemon_config.enable` is `true`, but when it is `false` it ignores the file, rather than cleans it up.  This means when we
reconfigure metron_agent to no longer handle rsyslog forwarding, it may still be forwarding due to the remnant configuration file.

Here we add a complementary job that when `syslog_daemon_config.enable` is `false` will remove the configuration and restart rsyslogd, if that config file happens to be present.
# How to review
- Deploy metron_agent with syslog forwarding enabled.
- Set `syslog_daemon_config.enable`, redeploy
- Observe that the file /etc/rsyslog.d/00-syslog_forwarder.conf remains
- Add the `cleanup_syslog_forwarding` job to the node, redeploy
- Observe that the file /etc/rsyslog.d/00-syslog_forwarder.conf has been removed
# Who can review

Not @paroxp or @richardc
